### PR TITLE
fix(cloudregistration): CSPG-63573 - fix deployment fail issue when microsoft_graph_permission_ids is not specified

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,11 +5,20 @@ locals {
   management_groups           = toset(length(var.subscription_ids) == 0 && length(var.management_group_ids) == 0 ? [data.azurerm_client_config.current.tenant_id] : var.management_group_ids)
   env                         = var.env == "" ? "" : "-${var.env}"
   should_deploy_log_ingestion = var.enable_realtime_visibility
+
+  microsoft_graph_permission_ids = var.microsoft_graph_permission_ids != null ? var.microsoft_graph_permission_ids : [
+    "9a5d68dd-52b0-4cc2-bd40-abcf44ac3a30", # Application.Read.All (Role)
+    "98830695-27a2-44f7-8c18-0c3ebc9698f6", # GroupMember.Read.All (Role)
+    "246dd0d5-5bd0-4def-940b-0421030a5b68", # Policy.Read.All (Role)
+    "230c1aed-a721-4c5d-9cb4-a90514e508ef", # Reports.Read.All (Role)
+    "483bed4a-2ad3-4361-a73b-c83ccdbdc53c", # RoleManagement.Read.Directory (Role)
+    "df021288-bdef-4463-88db-98f22de89214"  # User.Read.All (Role)
+  ]
 }
 
 resource "crowdstrike_cloud_azure_tenant" "this" {
   tenant_id                      = data.azurerm_client_config.current.tenant_id
-  microsoft_graph_permission_ids = var.microsoft_graph_permission_ids
+  microsoft_graph_permission_ids = local.microsoft_graph_permission_ids
   realtime_visibility = {
     enabled = var.enable_realtime_visibility
   }
@@ -25,7 +34,7 @@ module "service_principal" {
   source = "./modules/service-principal/"
 
   azure_client_id                = crowdstrike_cloud_azure_tenant.this.cs_azure_client_id
-  microsoft_graph_permission_ids = var.microsoft_graph_permission_ids != null ? var.microsoft_graph_permission_ids : []
+  microsoft_graph_permission_ids = local.microsoft_graph_permission_ids
 }
 
 module "asset_inventory" {

--- a/modules/service-principal/README.md
+++ b/modules/service-principal/README.md
@@ -37,11 +37,15 @@ module "service_principal" {
   # Client ID of CrowdStrike's multi-tenant app
   azure_client_id = "0805b105-a007-49b3-b575-14eed38fc1d0"
 
-  # Optionally customize Microsoft Graph app roles
-  # microsoft_graph_permission_ids = [
-  #   "9a5d68dd-52b0-4cc2-bd40-abcf44ac3a30", # Application.Read.All
-  #   "98830695-27a2-44f7-8c18-0c3ebc9698f6"  # GroupMember.Read.All
-  # ]
+  # Customize Microsoft Graph app roles
+  microsoft_graph_permission_ids = [
+    "9a5d68dd-52b0-4cc2-bd40-abcf44ac3a30", # Application.Read.All (Role)
+    "98830695-27a2-44f7-8c18-0c3ebc9698f6", # GroupMember.Read.All (Role)
+    "246dd0d5-5bd0-4def-940b-0421030a5b68", # Policy.Read.All (Role)
+    "230c1aed-a721-4c5d-9cb4-a90514e508ef", # Reports.Read.All (Role)
+    "483bed4a-2ad3-4361-a73b-c83ccdbdc53c", # RoleManagement.Read.Directory (Role)
+    "df021288-bdef-4463-88db-98f22de89214"  # User.Read.All (Role)
+  ]
 }
 ```
 

--- a/modules/service-principal/docs/.usage.tf
+++ b/modules/service-principal/docs/.usage.tf
@@ -25,9 +25,13 @@ module "service_principal" {
   # Client ID of CrowdStrike's multi-tenant app
   azure_client_id = "0805b105-a007-49b3-b575-14eed38fc1d0"
 
-  # Optionally customize Microsoft Graph app roles
-  # microsoft_graph_permission_ids = [
-  #   "9a5d68dd-52b0-4cc2-bd40-abcf44ac3a30", # Application.Read.All
-  #   "98830695-27a2-44f7-8c18-0c3ebc9698f6"  # GroupMember.Read.All
-  # ]
+  # Customize Microsoft Graph app roles
+  microsoft_graph_permission_ids = [
+    "9a5d68dd-52b0-4cc2-bd40-abcf44ac3a30", # Application.Read.All (Role)
+    "98830695-27a2-44f7-8c18-0c3ebc9698f6", # GroupMember.Read.All (Role)
+    "246dd0d5-5bd0-4def-940b-0421030a5b68", # Policy.Read.All (Role)
+    "230c1aed-a721-4c5d-9cb4-a90514e508ef", # Reports.Read.All (Role)
+    "483bed4a-2ad3-4361-a73b-c83ccdbdc53c", # RoleManagement.Read.Directory (Role)
+    "df021288-bdef-4463-88db-98f22de89214"  # User.Read.All (Role)
+  ]
 }

--- a/modules/service-principal/variables.tf
+++ b/modules/service-principal/variables.tf
@@ -11,15 +11,8 @@ variable "azure_client_id" {
 variable "microsoft_graph_permission_ids" {
   description = "List of Microsoft Graph app role IDs to assign to the service principal"
   type        = list(string)
-  default = [
-    "9a5d68dd-52b0-4cc2-bd40-abcf44ac3a30", # Application.Read.All (Role)
-    "98830695-27a2-44f7-8c18-0c3ebc9698f6", # GroupMember.Read.All (Role)
-    "246dd0d5-5bd0-4def-940b-0421030a5b68", # Policy.Read.All (Role)
-    "230c1aed-a721-4c5d-9cb4-a90514e508ef", # Reports.Read.All (Role)
-    "483bed4a-2ad3-4361-a73b-c83ccdbdc53c", # RoleManagement.Read.Directory (Role)
-    "df021288-bdef-4463-88db-98f22de89214"  # User.Read.All (Role)
-  ]
-  nullable = false
+  default     = []
+  nullable    = false
 
   validation {
     condition     = alltrue([for id in var.microsoft_graph_permission_ids : can(regex("^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$", id))])


### PR DESCRIPTION
# Scope

- Fix the deployment failed issue when the optional parameter `microsoft_graph_permission_ids` is not specified
```bash
│ Error: Missing Configuration for Required Attribute
│ 
│   with module.crowdstrike_azure_registration.crowdstrike_cloud_azure_tenant.this,
│   on .terraform/modules/crowdstrike_azure_registration/main.tf line 12, in resource "crowdstrike_cloud_azure_tenant" "this":
│   12:   microsoft_graph_permission_ids = var.microsoft_graph_permission_ids
│ 
│ Must set a configuration value for the microsoft_graph_permission_ids attribute as the provider has marked it as required.
│ 
│ Refer to the provider documentation or contact the provider developers for additional information about configurable attributes that are required.
```

Issue: CSPG-63573