### PR TITLE
fix(cloudregistration): allow trusted service access option of Event Hub and fix missing parameters for tenant registration resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,12 +22,14 @@ resource "crowdstrike_cloud_azure_tenant" "this" {
   realtime_visibility = {
     enabled = var.enable_realtime_visibility
   }
-  resource_name_prefix = var.resource_suffix
-  resource_name_suffix = var.resource_suffix
-  environment          = var.env
-  management_group_ids = var.management_group_ids
-  subscription_ids     = var.subscription_ids
-  tags                 = var.tags
+  cs_infra_subscription_id = var.cs_infra_subscription_id
+  cs_infra_location        = var.location
+  resource_name_prefix     = var.resource_prefix
+  resource_name_suffix     = var.resource_suffix
+  environment              = var.env
+  management_group_ids     = var.management_group_ids
+  subscription_ids         = var.subscription_ids
+  tags                     = var.tags
 }
 
 module "service_principal" {

--- a/modules/log-ingestion/main.tf
+++ b/modules/log-ingestion/main.tf
@@ -43,8 +43,9 @@ resource "azurerm_eventhub_namespace" "this" {
   minimum_tls_version           = "1.2"
   public_network_access_enabled = true
   network_rulesets {
-    default_action                = "Deny"
-    public_network_access_enabled = true
+    default_action                 = "Deny"
+    public_network_access_enabled  = true
+    trusted_service_access_enabled = true
     ip_rule = [for ip in var.falcon_ip_addresses : {
       ip_mask = ip
       action  = "Allow"


### PR DESCRIPTION
# JIRA

- CSPG-63689: `trusted_service_access_enabled` should be enabled for Event Hub namespace when RTV&D is enabled
- CSPG-63690: Running terraform apply plan.out  in Provider produced inconsistent result after apply

# Scope

- Enable `trusted_service_access_enabled` for Event Hub namespace
- Add missing parameters `cs_infra_subscription_id` and `cs_infra_location` to `crowdstrike_cloud_azure_tenant` resource
- Fix parameter `resource_name_prefix` of `crowdstrike_cloud_azure_tenant` resource
