### PR TITLE
feat(cloudregistration): update the official version of crowdstrike terraform provider for supporting new fcs azure registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ terraform {
 
     crowdstrike = {
       source  = "Crowdstrike/crowdstrike"
-      version = ">= 0.0.19" # TODO: change to use the finalized version for FCS Azure Cloud Registration
+      version = ">= 0.0.29"
     }
   }
 }

--- a/docs/.usage.tf
+++ b/docs/.usage.tf
@@ -12,7 +12,7 @@ terraform {
 
     crowdstrike = {
       source  = "Crowdstrike/crowdstrike"
-      version = ">= 0.0.19" # TODO: change to use the finalized version for FCS Azure Cloud Registration
+      version = ">= 0.0.29"
     }
   }
 }

--- a/examples/individual-subscriptions-deployment/versions.tf
+++ b/examples/individual-subscriptions-deployment/versions.tf
@@ -19,7 +19,7 @@ terraform {
 
     crowdstrike = {
       source  = "Crowdstrike/crowdstrike"
-      version = ">= 0.0.19" # TODO: change to use the finalized version for FCS Azure Cloud Registration
+      version = ">= 0.0.29"
     }
   }
 }

--- a/examples/management-groups-deployment/versions.tf
+++ b/examples/management-groups-deployment/versions.tf
@@ -19,7 +19,7 @@ terraform {
 
     crowdstrike = {
       source  = "Crowdstrike/crowdstrike"
-      version = ">= 0.0.19" # TODO: change to use the finalized version for FCS Azure Cloud Registration
+      version = ">= 0.0.29"
     }
   }
 }

--- a/examples/tenant-deployment/versions.tf
+++ b/examples/tenant-deployment/versions.tf
@@ -19,7 +19,7 @@ terraform {
 
     crowdstrike = {
       source  = "Crowdstrike/crowdstrike"
-      version = ">= 0.0.19" # TODO: change to use the finalized version for FCS Azure Cloud Registration
+      version = ">= 0.0.29"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -19,7 +19,7 @@ terraform {
 
     crowdstrike = {
       source  = "Crowdstrike/crowdstrike"
-      version = ">= 0.0.19" # TODO: change to use the finalized version for FCS Azure Cloud Registration
+      version = ">= 0.0.29"
     }
   }
 }


### PR DESCRIPTION
# Scope

Update the version of CrowdStrike Terraform Provider to `v0.0.29` supporting the new FCS Azure registration