### PR TITLE
fix: improve input variable validation rules

### DIFF
--- a/examples/individual-subscriptions-deployment/variables.tf
+++ b/examples/individual-subscriptions-deployment/variables.tf
@@ -12,20 +12,20 @@ variable "falcon_client_id" {
   type        = string
   sensitive   = true
   default     = ""
-  description = "Falcon API client ID. Required when `enable_realtime_visibility` is set to `true`."
+  description = "Falcon API client ID."
   validation {
-    condition     = !var.enable_realtime_visibility || (length(var.falcon_client_id) == 32 && can(regex("^[a-fA-F0-9]+$", var.falcon_client_id)))
-    error_message = "falcon_client_id is required when enable_realtime_visibility is set to true and must be a 32-character hexadecimal string. Please use the Falcon console to generate a new API key/secret pair with appropriate scopes."
+    condition     = length(var.falcon_client_id) == 32 && can(regex("^[a-fA-F0-9]+$", var.falcon_client_id))
+    error_message = "falcon_client_id must be a 32-character hexadecimal string. Please use the Falcon console to generate a new API key/secret pair with appropriate scopes."
   }
 }
 
 variable "falcon_client_secret" {
   type        = string
   sensitive   = true
-  description = "Falcon API client secret. Required when `enable_realtime_visibility` is set to `true`."
+  description = "Falcon API client secret."
   validation {
-    condition     = !var.enable_realtime_visibility || (length(var.falcon_client_secret) == 40 && can(regex("^[a-zA-Z0-9]+$", var.falcon_client_secret)))
-    error_message = "falcon_client_secret is required when enable_realtime_visibility is set to true and must be a 40-character hexadecimal string. Please use the Falcon console to generate a new API key/secret pair with appropriate scopes."
+    condition     = length(var.falcon_client_secret) == 40 && can(regex("^[a-zA-Z0-9]+$", var.falcon_client_secret))
+    error_message = "falcon_client_secret must be a 40-character hexadecimal string. Please use the Falcon console to generate a new API key/secret pair with appropriate scopes."
   }
 }
 

--- a/examples/management-groups-deployment/variables.tf
+++ b/examples/management-groups-deployment/variables.tf
@@ -22,20 +22,20 @@ variable "falcon_client_id" {
   type        = string
   sensitive   = true
   default     = ""
-  description = "Falcon API client ID. Required when `enable_realtime_visibility` is set to `true`."
+  description = "Falcon API client ID."
   validation {
-    condition     = !var.enable_realtime_visibility || (length(var.falcon_client_id) == 32 && can(regex("^[a-fA-F0-9]+$", var.falcon_client_id)))
-    error_message = "falcon_client_id is required when enable_realtime_visibility is set to true and must be a 32-character hexadecimal string. Please use the Falcon console to generate a new API key/secret pair with appropriate scopes."
+    condition     = length(var.falcon_client_id) == 32 && can(regex("^[a-fA-F0-9]+$", var.falcon_client_id))
+    error_message = "falcon_client_id must be a 32-character hexadecimal string. Please use the Falcon console to generate a new API key/secret pair with appropriate scopes."
   }
 }
 
 variable "falcon_client_secret" {
   type        = string
   sensitive   = true
-  description = "Falcon API client secret. Required when `enable_realtime_visibility` is set to `true`."
+  description = "Falcon API client secret."
   validation {
-    condition     = !var.enable_realtime_visibility || (length(var.falcon_client_secret) == 40 && can(regex("^[a-zA-Z0-9]+$", var.falcon_client_secret)))
-    error_message = "falcon_client_secret is required when enable_realtime_visibility is set to true and must be a 40-character hexadecimal string. Please use the Falcon console to generate a new API key/secret pair with appropriate scopes."
+    condition     = length(var.falcon_client_secret) == 40 && can(regex("^[a-zA-Z0-9]+$", var.falcon_client_secret))
+    error_message = "falcon_client_secret must be a 40-character hexadecimal string. Please use the Falcon console to generate a new API key/secret pair with appropriate scopes."
   }
 }
 

--- a/examples/tenant-deployment/variables.tf
+++ b/examples/tenant-deployment/variables.tf
@@ -2,20 +2,20 @@ variable "falcon_client_id" {
   type        = string
   sensitive   = true
   default     = ""
-  description = "Falcon API client ID. Required when `enable_realtime_visibility` is set to `true`."
+  description = "Falcon API client ID."
   validation {
-    condition     = !var.enable_realtime_visibility || (length(var.falcon_client_id) == 32 && can(regex("^[a-fA-F0-9]+$", var.falcon_client_id)))
-    error_message = "falcon_client_id is required when enable_realtime_visibility is set to true and must be a 32-character hexadecimal string. Please use the Falcon console to generate a new API key/secret pair with appropriate scopes."
+    condition     = length(var.falcon_client_id) == 32 && can(regex("^[a-fA-F0-9]+$", var.falcon_client_id))
+    error_message = "falcon_client_id must be a 32-character hexadecimal string. Please use the Falcon console to generate a new API key/secret pair with appropriate scopes."
   }
 }
 
 variable "falcon_client_secret" {
   type        = string
   sensitive   = true
-  description = "Falcon API client secret. Required when `enable_realtime_visibility` is set to `true`."
+  description = "Falcon API client secret."
   validation {
-    condition     = !var.enable_realtime_visibility || (length(var.falcon_client_secret) == 40 && can(regex("^[a-zA-Z0-9]+$", var.falcon_client_secret)))
-    error_message = "falcon_client_secret is required when enable_realtime_visibility is set to true and must be a 40-character hexadecimal string. Please use the Falcon console to generate a new API key/secret pair with appropriate scopes."
+    condition     = length(var.falcon_client_secret) == 40 && can(regex("^[a-zA-Z0-9]+$", var.falcon_client_secret))
+    error_message = "falcon_client_secret must be a 40-character hexadecimal string. Please use the Falcon console to generate a new API key/secret pair with appropriate scopes."
   }
 }
 

--- a/modules/asset-inventory/variables.tf
+++ b/modules/asset-inventory/variables.tf
@@ -34,10 +34,24 @@ variable "resource_prefix" {
   description = "Prefix to be added to all created resource names for identification"
   default     = ""
   type        = string
+
+  validation {
+    condition     = length(var.resource_prefix) + length(var.resource_suffix) <= 10
+    error_message = "The combined length of resource_prefix and resource_suffix must be 10 characters or less."
+  }
+  validation {
+    condition     = var.resource_prefix == "" || can(regex("^[a-zA-Z][a-zA-Z0-9-]*$", var.resource_prefix))
+    error_message = "resource_prefix can only contain letters, numbers, and hyphens, and must start with a letter."
+  }
 }
 
 variable "resource_suffix" {
   description = "Suffix to be added to all created resource names for identification"
   default     = ""
   type        = string
+
+  validation {
+    condition     = var.resource_suffix == "" || can(regex("^[a-zA-Z0-9-]*[a-zA-Z0-9]$", var.resource_suffix))
+    error_message = "resource_suffix can only contain letters, numbers, and hyphens, and must end with a letter or number."
+  }
 }

--- a/modules/log-ingestion/variables.tf
+++ b/modules/log-ingestion/variables.tf
@@ -78,6 +78,11 @@ variable "env" {
   description = "Environment label (for example, prod, stag, dev) used for resource naming and tagging. Helps distinguish between different deployment environments. Limited to 4 alphanumeric characters for compatibility with resource naming restrictions."
   default     = "prod"
   type        = string
+
+  validation {
+    condition     = var.env == "" || (length(var.env) <= 4 && can(regex("^[0-9a-zA-Z]*$", var.env)))
+    error_message = "The 'env' must only contain alphanumeric characters and has a limit of 4 characters."
+  }
 }
 
 variable "location" {
@@ -90,12 +95,26 @@ variable "resource_prefix" {
   description = "Prefix to be added to all created resource names for identification"
   default     = ""
   type        = string
+
+  validation {
+    condition     = length(var.resource_prefix) + length(var.resource_suffix) <= 10
+    error_message = "The combined length of resource_prefix and resource_suffix must be 10 characters or less."
+  }
+  validation {
+    condition     = var.resource_prefix == "" || can(regex("^[a-zA-Z][a-zA-Z0-9-]*$", var.resource_prefix))
+    error_message = "resource_prefix can only contain letters, numbers, and hyphens, and must start with a letter."
+  }
 }
 
 variable "resource_suffix" {
   description = "Suffix to be added to all created resource names for identification"
   default     = ""
   type        = string
+
+  validation {
+    condition     = var.resource_suffix == "" || can(regex("^[a-zA-Z0-9-]*[a-zA-Z0-9]$", var.resource_suffix))
+    error_message = "resource_suffix can only contain letters, numbers, and hyphens, and must end with a letter or number."
+  }
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -70,7 +70,7 @@ variable "env" {
   type        = string
 
   validation {
-    condition     = var.env == "" || can(regex("^[0-9a-zA-Z]{4}$", var.env))
+    condition     = var.env == "" || (length(var.env) <= 4 && can(regex("^[0-9a-zA-Z]*$", var.env)))
     error_message = "The 'env' must only contain alphanumeric characters and has a limit of 4 characters."
   }
 }
@@ -125,12 +125,26 @@ variable "resource_prefix" {
   description = "Prefix to be added to all created resource names for identification"
   default     = ""
   type        = string
+
+  validation {
+    condition     = length(var.resource_prefix) + length(var.resource_suffix) <= 10
+    error_message = "The combined length of resource_prefix and resource_suffix must be 10 characters or less."
+  }
+  validation {
+    condition     = var.resource_prefix == "" || can(regex("^[a-zA-Z][a-zA-Z0-9-]*$", var.resource_prefix))
+    error_message = "resource_prefix can only contain letters, numbers, and hyphens, and must start with a letter."
+  }
 }
 
 variable "resource_suffix" {
   description = "Suffix to be added to all created resource names for identification"
   default     = ""
   type        = string
+
+  validation {
+    condition     = var.resource_suffix == "" || can(regex("^[a-zA-Z0-9-]*[a-zA-Z0-9]$", var.resource_suffix))
+    error_message = "resource_suffix can only contain letters, numbers, and hyphens, and must end with a letter or number."
+  }
 }
 
 variable "tags" {


### PR DESCRIPTION
## JIRA

- [CSPG-69312](https://jira.cs.sys/browse/CSPG-69312): Implement prefix/suffix length restriction in Terraform template

## Summary
- Fixed env variable validation to allow values with 1-4 characters instead of requiring exactly 4 characters
- Added comprehensive validation rules for resource_prefix and resource_suffix variables:
  - Combined length validation (≤10 characters total)
  - Format validation with proper regex patterns
  - Updated across all modules and examples for consistency
- Simplified falcon_client_id and falcon_client_secret validation in examples by removing enable_realtime_visibility dependency

## Changes Made
- **Root module (variables.tf)**: Updated env variable regex from `^[0-9a-zA-Z]{4}$` to `^[0-9a-zA-Z]*$` with length check
- **All modules**: Added validation rules for resource_prefix and resource_suffix with combined length and format restrictions
- **Example files**: Simplified falcon client credential validation rules

## Test Plan
- [x] Validate terraform plan with various env values (1-4 characters)
- [x] Test resource_prefix and resource_suffix combinations within 10 character limit
- [x] Verify prefix starts with letter and suffix ends with letter/number
- [x] Test validation errors with invalid inputs
