### PR TITLE
CSPG-97312: Fix rg_scanner role assignment 400 on target subscriptions

### DIFF
--- a/modules/agentless-scanning/roles/assignments/main.tf
+++ b/modules/agentless-scanning/roles/assignments/main.tf
@@ -35,7 +35,7 @@ resource "azurerm_role_assignment" "rg_scanner_reader" {
 }
 
 resource "azurerm_role_assignment" "rg_scanner" {
-  count = var.enable_vulnerability_scanning ? 1 : 0
+  count = var.enable_vulnerability_scanning && var.is_host ? 1 : 0
 
   scope              = "/subscriptions/${local.subscription_id}/resourceGroups/${var.resource_group_name}"
   role_definition_id = var.role_definition_ids.rg_scanner

--- a/modules/agentless-scanning/roles/definitions/main.tf
+++ b/modules/agentless-scanning/roles/definitions/main.tf
@@ -90,7 +90,7 @@ resource "azurerm_role_definition" "custom_vnet_subnet" {
 }
 
 resource "azurerm_role_definition" "rg_scanner" {
-  count = var.enable_vulnerability_scanning && var.is_host ? 1 : 0
+  count = var.enable_vulnerability_scanning && (var.is_host || var.scope_type == "mg") ? 1 : 0
 
   name        = "${var.resource_prefix}role-csscanning-rg-scanner-${var.scope_id}${var.resource_suffix}"
   scope       = local.scope

--- a/modules/agentless-scanning/roles/definitions/main.tf
+++ b/modules/agentless-scanning/roles/definitions/main.tf
@@ -90,7 +90,7 @@ resource "azurerm_role_definition" "custom_vnet_subnet" {
 }
 
 resource "azurerm_role_definition" "rg_scanner" {
-  count = var.enable_vulnerability_scanning && (var.is_host || var.scope_type == "mg") ? 1 : 0
+  count = var.enable_vulnerability_scanning && var.is_host ? 1 : 0
 
   name        = "${var.resource_prefix}role-csscanning-rg-scanner-${var.scope_id}${var.resource_suffix}"
   scope       = local.scope


### PR DESCRIPTION
## Summary
- Fixes a 400 `BadRequestFormat` on `azurerm_role_assignment.rg_scanner` when onboarding a target subscription (regular cross-account **and** management-group cross-account) with `enable_vulnerability_scanning = true`.
- Root cause: the `rg_scanner` **assignment** was gated only on `enable_vulnerability_scanning`, while its role **definition** was gated on `enable_vulnerability_scanning && (is_host || scope_type == "mg")`. For a target sub (`is_host=false`, `scope_type="subscription"`) the definition is not created, so its output id is `""` and the assignment sends an empty `role_definition_id` to Azure.

### Changes
- `modules/agentless-scanning/roles/assignments/main.tf` — gate the `rg_scanner` assignment on `is_host` (`enable_vulnerability_scanning && var.is_host`). The role grants `attachDetachDataDisks` and is only needed on the host where scanner VMs run, never on target subs.

### Notes
- The `rg_scanner` **definition** intentionally keeps its `scope_type == "mg"` clause: MG-scoped role definitions are created once per management group and shared by every subscription in that MG via `scanning_role_definition_ids`. A host subscription in an MG other than `host_mg_id` still consumes that MG's shared definitions, so every MG must carry `rg_scanner`. Only the assignment is host-scoped.
- Host behavior (subscription- or MG-scope) is unchanged: it still creates both the definition and the assignment.

## Jira
[CSPG-97312](https://jira.cs.sys/browse/CSPG-97312)