### PR TITLE
fix(log-ingestion): CSPG-98254 Filter NetworkAccessTrafficLogs from Entra ID diagnostic settings in Azure Government

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -112,6 +112,7 @@ module "log_ingestion" {
   resource_prefix          = var.resource_prefix
   resource_suffix          = var.resource_suffix
   tags                     = var.tags
+  account_type             = var.account_type
 
   depends_on = [module.crowdstrike_resource_group]
 }

--- a/modules/log-ingestion/README.md
+++ b/modules/log-ingestion/README.md
@@ -158,6 +158,7 @@ module "log_ingestion" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_account_type"></a> [account\_type](#input\_account\_type) | Azure account type: 'commercial' or 'gov'. Used to omit diagnostic log categories not supported in Azure Government. | `string` | `"commercial"` | no |
 | <a name="input_activity_log_settings"></a> [activity\_log\_settings](#input\_activity\_log\_settings) | Configuration settings for Azure Activity Log ingestion | <pre>object({<br/>    enabled = bool<br/>    existing_eventhub = optional(object({<br/>      use                          = bool<br/>      eventhub_resource_id         = optional(string, "")<br/>      eventhub_consumer_group_name = optional(string, "")<br/>    }), { use = false })<br/>  })</pre> | <pre>{<br/>  "enabled": true<br/>}</pre> | no |
 | <a name="input_app_service_principal_id"></a> [app\_service\_principal\_id](#input\_app\_service\_principal\_id) | Service principal ID of CrowdStrike app to which all the roles will be assigned for log ingestion | `string` | n/a | yes |
 | <a name="input_cs_infra_subscription_id"></a> [cs\_infra\_subscription\_id](#input\_cs\_infra\_subscription\_id) | Azure subscription ID where CrowdStrike infrastructure resources, such as Event Hubs, will be deployed. This subscription must be accessible with the current credentials. | `string` | n/a | yes |

--- a/modules/log-ingestion/diagnostic-settings.tf
+++ b/modules/log-ingestion/diagnostic-settings.tf
@@ -41,45 +41,14 @@ resource "azurerm_monitor_aad_diagnostic_setting" "entra_id_log" {
   name                           = local.entra_id_log_diagnostic_settings_default_name
   eventhub_name                  = azurerm_eventhub.entra_id_log[0].name
   eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.this[0].id
-  enabled_log {
-    category = "AuditLogs"
+
+  dynamic "enabled_log" {
+    for_each = local.entra_id_log_categories
+    content {
+      category = enabled_log.value
+    }
   }
-  enabled_log {
-    category = "SignInLogs"
-  }
-  enabled_log {
-    category = "NonInteractiveUserSignInLogs"
-  }
-  enabled_log {
-    category = "ServicePrincipalSignInLogs"
-  }
-  enabled_log {
-    category = "ManagedIdentitySignInLogs"
-  }
-  enabled_log {
-    category = "ADFSSignInLogs"
-  }
-  enabled_log {
-    category = "MicrosoftGraphActivityLogs"
-  }
-  enabled_log {
-    category = "ProvisioningLogs"
-  }
-  enabled_log {
-    category = "UserRiskEvents"
-  }
-  enabled_log {
-    category = "RiskyUsers"
-  }
-  enabled_log {
-    category = "RiskyServicePrincipals"
-  }
-  enabled_log {
-    category = "ServicePrincipalRiskEvents"
-  }
-  enabled_log {
-    category = "NetworkAccessTrafficLogs"
-  }
+
   depends_on = [
     azurerm_eventhub.entra_id_log
   ]

--- a/modules/log-ingestion/main.tf
+++ b/modules/log-ingestion/main.tf
@@ -6,6 +6,36 @@ locals {
   should_deploy_eventhub_for_entra_id_log       = var.entra_id_log_settings.enabled && !var.entra_id_log_settings.existing_eventhub.use
   should_deploy_eventhub_namespace              = local.should_deploy_eventhub_for_activity_log || local.should_deploy_eventhub_for_entra_id_log
   env                                           = var.env == "" ? "" : "-${var.env}"
+
+  # Full set of Entra ID diagnostic log categories CrowdStrike ingests.
+  # Kept as a list so gov-incompatible entries can be filtered below.
+  entra_id_log_categories_all = [
+    "AuditLogs",
+    "SignInLogs",
+    "NonInteractiveUserSignInLogs",
+    "ServicePrincipalSignInLogs",
+    "ManagedIdentitySignInLogs",
+    "ADFSSignInLogs",
+    "MicrosoftGraphActivityLogs",
+    "ProvisioningLogs",
+    "UserRiskEvents",
+    "RiskyUsers",
+    "RiskyServicePrincipals",
+    "ServicePrincipalRiskEvents",
+    "NetworkAccessTrafficLogs",
+  ]
+
+  # Categories tied to Microsoft Entra Internet Access / Private Access (Global Secure Access),
+  # which is not available in Azure Government. Azure rejects the whole diagnostic setting
+  # if any of these are included in a Gov deployment.
+  entra_id_log_categories_gov_unsupported = [
+    "NetworkAccessTrafficLogs",
+  ]
+
+  entra_id_log_categories = var.account_type == "gov" ? [
+    for c in local.entra_id_log_categories_all :
+    c if !contains(local.entra_id_log_categories_gov_unsupported, c)
+  ] : local.entra_id_log_categories_all
 }
 
 data "azurerm_client_config" "this" {}

--- a/modules/log-ingestion/variables.tf
+++ b/modules/log-ingestion/variables.tf
@@ -129,3 +129,13 @@ variable "tags" {
     error_message = "The tags map cannot contain more than 45 entries."
   }
 }
+
+variable "account_type" {
+  type        = string
+  default     = "commercial"
+  description = "Azure account type: 'commercial' or 'gov'. Used to omit diagnostic log categories not supported in Azure Government."
+  validation {
+    condition     = var.account_type == "commercial" || var.account_type == "gov"
+    error_message = "must be either 'commercial' or 'gov'"
+  }
+}


### PR DESCRIPTION
## Problem

Gov Cloud customers cannot register their Azure Gov tenant to the CrowdStrike IDAAS connector. The `az stack mg create` deployment fails with:

```
BadRequest: Category 'NetworkAccessTrafficLogs' is not supported.
```

`NetworkAccessTrafficLogs` is a Global Secure Access (Entra Internet Access / Private Access) category that does not exist in Azure Government. Azure rejects the **entire** diagnostic setting on the first unsupported category, blocking all Gov IDAAS onboarding.

**Root cause**: Commit `8f436cd` (CSPG-91459) added 7 new Entra ID log categories. The `account_type` variable (`commercial` | `gov`) existed at the root module level but was only forwarded to `crowdstrike_cloud_azure_tenant.this` — never into the `log-ingestion` submodule. Categories were hardcoded unconditionally.

## Solution

Three-file change, all backwards-compatible:

1. **`modules/log-ingestion/variables.tf`** — add `account_type` input (default `commercial`).
2. **`main.tf`** — pass `account_type = var.account_type` into `module "log_ingestion"`.
3. **`modules/log-ingestion/main.tf` + `diagnostic-settings.tf`** — refactor the hardcoded `enabled_log` blocks into a filterable locals list (`entra_id_log_categories_all`) + `dynamic` block. A separate `entra_id_log_categories_gov_unsupported` list holds the GSA-tied categories, making future additions trivial.

Commercial deployments are unaffected (all 13 categories). Gov deployments drop `NetworkAccessTrafficLogs` (12 categories).

## Configuration

No new required inputs. `account_type` already exists at the root module level and defaults to `commercial` — existing callers require no changes. Gov users already set `account_type = "gov"` to register with the correct CrowdStrike partition; the fix flows automatically from that.

## Security

No new attack surface. This is a reduction in scope for Gov environments, aligning Azure resource configuration with what the cloud partition actually supports.

## Test Plan

- `terraform validate` passes on `modules/log-ingestion/` and `examples/tenant-deployment/`
- `terraform fmt -recursive -check` passes
- `terraform plan` with `account_type=commercial` — 13 categories, no drift
- `terraform plan` with `account_type=gov` — 12 categories, `NetworkAccessTrafficLogs` absent
- End-to-end: Gov tenant IDAAS registration completes without `BadRequest: Category 'NetworkAccessTrafficLogs' is not supported`

## Logging

No log changes.

## Scale

No scale implications. Diagnostic setting category list is static config evaluated at plan time.

## Rollout

Standard — no sequencing required. Change takes effect on the next `terraform apply` for Gov tenants. Commercial tenants are unaffected.

Resolves: [CSPG-98254](https://jira.cs.sys/browse/CSPG-98254)
Related: [CSPG-91459](https://jira.cs.sys/browse/CSPG-91459)